### PR TITLE
Update InternalSchedule.cs

### DIFF
--- a/FluentScheduler/Scheduler/InternalSchedule.cs
+++ b/FluentScheduler/Scheduler/InternalSchedule.cs
@@ -144,6 +144,10 @@ namespace FluentScheduler
             // raising JobEnded event
             JobEnded?.Invoke(this, new JobEndedEventArgs(exception, startTime, endTime, NextRun));
 
+            // if invoke stop in job
+            if (token.IsCancellationRequested)
+                return;
+            
             // recursive call
             // note that the NextRun was already calculated in this run
             _task = Run(token);


### PR DESCRIPTION
If you call the scheduler stop method from the job method, then _task will still take the value of the new action, and true will be returned when checking for the Running state.